### PR TITLE
Fixed maven warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     </properties>
 
     <build>
-        <finalName>mymap-v${version}</finalName>
+        <finalName>mymap-v${project.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
```
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for com.zfkun.plugins:plugin-mymap:jar:1.1.2
[WARNING] The expression ${version} is deprecated. Please use ${project.version} instead.
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
[INFO]
[INFO] -------------------< com.zfkun.plugins:plugin-mymap >-------------------
[INFO] Building plugin-mymap 1.1.2
[INFO] --------------------------------[ jar ]---------------------------------
```